### PR TITLE
Add volume command to adjust volume dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `/resume`.
     - `/pause`.
     - `/sync`.
+    - `/volume`.
 - An acknowledgements section in the `README.md` file.
 - CI/CD linting, formatting, publishing and Docker building.
 - Publish the package to PyPI.

--- a/src/disopy/cogs/queue.py
+++ b/src/disopy/cogs/queue.py
@@ -373,3 +373,19 @@ class QueueCog(Base):
             content.append(f"- **{song.title}**")
 
         await self.send_embed(interaction, f"Queue ({self.queue.length(interaction)} remaining)", content)
+
+    @app_commands.command(description="Adjust the volume")
+    async def volume(self, interaction: Interaction, volume: int) -> None:
+        """Adjust the volume of the playback.
+
+        Args:
+            interaction: The interaction that started the command.
+            volume: The new volume level.
+        """
+
+        if volume < 0 or volume > 100:
+            await self.send_embed(interaction, "Volume must be between 0 and 100")
+            return
+
+        self.config.volume = volume
+        await self.send_embed(interaction, f"Volume set to {volume}%")

--- a/src/disopy/config.py
+++ b/src/disopy/config.py
@@ -39,6 +39,45 @@ class Config(NamedTuple):
     developer_discord_sync_guild: int | None
     developer_discord_sync_users: list[int]
 
+    def update_volume(self, new_volume: int) -> None:
+        """Update the volume setting in the config.
+
+        Args:
+            new_volume: The new volume level.
+        """
+        self.volume = new_volume
+
+    def save(self, config_path: Path) -> None:
+        """Save the updated config to the config file.
+
+        Args:
+            config_path: The path to the folder where config file should be stored.
+        """
+        config_file = get_config_file_path(config_path)
+
+        doc = document()
+        doc.add(comment(f"{APP_NAME} config file"))
+        doc.add(nl())
+
+        doc.add(comment("DO NOT MODIFY ME! Internal config file version"))
+        doc.add("version", item(self.version))
+        doc.add(comment("The volume of the music playback in percentage"))
+        doc.add("volume", item(self.volume))
+
+        doc.add(nl())
+
+        subsonic_table = table()
+        subsonic_table.add(comment("The URL where the OpenSubsonic REST API can be accessed"))
+        subsonic_table.add("url", self.subsonic_url)
+
+        subsonic_table.add(comment("The user to be used when authenticating in the OpenSubsonic server"))
+        subsonic_table.add("user", self.subsonic_user)
+
+        doc.add("subsonic", subsonic_table)
+
+        with open(config_file, "w") as f:
+            f.write(doc.as_string())
+
 
 def get_config_file_path(config_path: Path) -> Path:
     """Get the config file path and generate the file.


### PR DESCRIPTION
Fixes #3

Add a new command to adjust the volume dynamically.

* **New Command:**
  - Add `/volume` command in `src/disopy/cogs/queue.py` to adjust the volume dynamically.
  - Validate the volume input to be between 0 and 100.
  - Update the volume setting and send a confirmation message.

* **Config Updates:**
  - Add `update_volume` method in `Config` class in `src/disopy/config.py` to update the volume setting.
  - Add `save` method in `Config` class to save the updated config to the config file.

* **Changelog:**
  - Add an entry for the new `/volume` command in `CHANGELOG.md`.

