### PR TITLE
Fix --generate-config not creating a config file

### DIFF
--- a/src/disopy/__main__.py
+++ b/src/disopy/__main__.py
@@ -21,16 +21,16 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     """The entry point of the program."""
 
-    env = get_env()
-    if env is None:
-        return
-
-    options = get_options(env.no_color)
+    options = get_options()
 
     setup_logging(options.debug >= 1, options.color)
 
     if options.generate_config:
         generate_new_config(options.config_path)
+        return
+
+    env = get_env()
+    if env is None:
         return
 
     config = get_config(options.config_path)

--- a/src/disopy/env.py
+++ b/src/disopy/env.py
@@ -49,15 +49,19 @@ def get_env_variable(variable_name: str, disable_critical_message: bool = False)
     return os.environ[env_name]
 
 
-def get_env() -> Env | None:
+def get_env(disable_critical_message: bool = False) -> Env | None:
     """Get the relevant environment of the program.
+
+    Args:
+        disable_critical_message: If an error message should not be printed
+            if the variable is not found.
 
     Returns:
         The environment of the program.
     """
 
-    subsonic_password = get_env_variable("SUBSONIC_PASSWORD")
-    discord_token = get_env_variable("DISCORD_TOKEN")
+    subsonic_password = get_env_variable("SUBSONIC_PASSWORD", disable_critical_message)
+    discord_token = get_env_variable("DISCORD_TOKEN", disable_critical_message)
 
     if subsonic_password is None or discord_token is None:
         return None


### PR DESCRIPTION
Fixes #12

Update `--generate-config` command to create a config file without requiring environment variables.

* **Main Function Changes:**
  - Move the `get_env` call after the `options.generate_config` check in `src/disopy/__main__.py`.
  - Add a return statement after the `generate_new_config` call in `src/disopy/__main__.py`.

* **Environment Function Changes:**
  - Add a new parameter `disable_critical_message` to the `get_env` function in `src/disopy/env.py`.
  - Modify the `get_env` function to use the `disable_critical_message` parameter in `src/disopy/env.py`.

