### PR TITLE
Fix TypeError in sync command

### DIFF
--- a/src/disopy/cogs/misc.py
+++ b/src/disopy/cogs/misc.py
@@ -56,7 +56,7 @@ class Misc(Base):
             interaction: The interaction that started the command.
         """
 
-        if interaction.user.id not in self.config.developer_discord_sync_users:
+        if str(interaction.user.id) not in self.config.developer_discord_sync_users:
             await self.send_error(interaction, ["❌ Action not authorized"], ephemeral=True)
             return
 


### PR DESCRIPTION
Fix the TypeError in the 'sync' command by converting `interaction.user.id` to a string.

* Convert `interaction.user.id` to a string before checking against `self.config.developer_discord_sync_users` in `src/disopy/cogs/misc.py` at line 59.

